### PR TITLE
feat: Added a "Verify CSR Signature"

### DIFF
--- a/src/components/shared/details-tabs/InformationTabContent.tsx
+++ b/src/components/shared/details-tabs/InformationTabContent.tsx
@@ -104,8 +104,8 @@ export const InformationTabContent: React.FC<InformationTabContentProps> = ({
       if (user?.access_token) {
         setIsLoadingProfiles(true);
         try {
-          const profiles = await fetchSigningProfiles(user.access_token);
-          setAvailableProfiles(profiles);
+          const profilesResponse = await fetchSigningProfiles(user.access_token);
+          setAvailableProfiles(profilesResponse.list);
         } catch (err) {
           console.error("Failed to load signing profiles:", err);
           toast({ title: "Error", description: "Could not load issuance profiles.", variant: "destructive" });

--- a/src/lib/dms-api.ts
+++ b/src/lib/dms-api.ts
@@ -34,6 +34,7 @@ export interface ApiRaEnrollmentSettings {
     enrollment_ca: string;
     protocol: string;
     enable_replaceable_enrollment: boolean;
+    verify_csr_signature?: boolean; // Optional field for backwards compatibility
     issuance_profile_id?: string; // Newly added field
     est_rfc7030_settings?: ApiRaEstSettings;
     device_provisioning_profile: {


### PR DESCRIPTION
This pull request enhances the registration authority creation/edit page by improving how default issuance profiles are displayed and adding a new option to verify CSR signatures during enrollment. It also makes UI improvements for better clarity and updates the handling of signing profiles to support new API response formats.

**UI/UX Improvements and New Features:**

* Added a "Verify CSR Signature" toggle to the form, allowing users to enable or disable cryptographic signature verification for CSRs during enrollment. This is now included in both the UI and the payload sent to the backend. [[1]](diffhunk://#diff-6c2191e8ca55f42039e8ef6361cfd97e72ac2c6023fd38be5e14c7ac0d577950R74) [[2]](diffhunk://#diff-6c2191e8ca55f42039e8ef6361cfd97e72ac2c6023fd38be5e14c7ac0d577950R188) [[3]](diffhunk://#diff-6c2191e8ca55f42039e8ef6361cfd97e72ac2c6023fd38be5e14c7ac0d577950R338) [[4]](diffhunk://#diff-6c2191e8ca55f42039e8ef6361cfd97e72ac2c6023fd38be5e14c7ac0d577950L503-R565) [[5]](diffhunk://#diff-9816e016ecc78c88f82f1c125a959d80f6fcb3ae14caf670e6c50fc2963a9951R37)
* Improved the display when no issuance profile is selected: the UI now shows details about the enrollment CA's default profile if available, or warns if the CA lacks a default profile. [[1]](diffhunk://#diff-6c2191e8ca55f42039e8ef6361cfd97e72ac2c6023fd38be5e14c7ac0d577950L122-R144) [[2]](diffhunk://#diff-6c2191e8ca55f42039e8ef6361cfd97e72ac2c6023fd38be5e14c7ac0d577950L503-R565)

**API and Data Handling Updates:**

* Updated the code to handle the new signing profiles API response format (`profilesResponse.list`), ensuring compatibility in both the registration authority page and the information tab content component. [[1]](diffhunk://#diff-6c2191e8ca55f42039e8ef6361cfd97e72ac2c6023fd38be5e14c7ac0d577950L122-R144) [[2]](diffhunk://#diff-74fd917037a5d1eb3be4921f6a4b9c51d2f7d8f03a611d1bb935d33c56236f26L107-R108)

**Code Structure and Type Updates:**

* Extended the `ApiRaEnrollmentSettings` interface to include the optional `verify_csr_signature` field for backward compatibility.