### PR TITLE
fix: add profile selector to import CA

### DIFF
--- a/src/app/certificate-authorities/issue-certificate/IssueCertificateFormClient.tsx
+++ b/src/app/certificate-authorities/issue-certificate/IssueCertificateFormClient.tsx
@@ -239,7 +239,7 @@ export default function IssueCertificateFormClient() {
         setIsLoadingProfiles(true);
         try {
             const profiles = await fetchSigningProfiles(user.access_token!);
-            setSigningProfiles(profiles);
+            setSigningProfiles(profiles.list);
         } catch (error: any) {
             toast({
                 title: "Error loading profiles",

--- a/src/app/certificate-authorities/new/page.tsx
+++ b/src/app/certificate-authorities/new/page.tsx
@@ -21,7 +21,7 @@ const creationModes: CreationMode[] = [
   {
     id: 'generate',
     href: '/certificate-authorities/new/generate',
-    title: 'Create New CA (Server-side Key)',
+    title: 'Create New CA (New Key Pair)',
     description: 'Provision a new Root or Intermediate Certification Authority directly. A new key is generated and managed by the KMS.',
     icon: <KeyRound className="h-8 w-8 text-primary" />,
   },

--- a/src/lib/ca-data.ts
+++ b/src/lib/ca-data.ts
@@ -699,15 +699,14 @@ export async function deleteCaRequest(requestId: string, accessToken: string): P
 
 // Function and type for importing a CA
 export interface ImportCaPayload {
-  request_id?: string;
-  id?: string;
-  engine_id?: string;
-  private_key?: string; // base64 encoded
-  ca: string; // base64 encoded
-  ca_chain?: string[]; // array of base64 encoded certs
-  ca_type: "MANAGED" | "IMPORTED" | "EXTERNAL_PUBLIC";
-  issuance_expiration?: { type: string; duration?: string; time?: string };
-  parent_id?: string;
+  id: string;
+  engine_id: string;
+  private_key: string;
+  ca: string;
+  ca_chain: string[];
+  ca_type: string;
+  profile_id?: string;
+  parent_id: string;
 }
 
 export async function importCa(payload: ImportCaPayload, accessToken: string): Promise<void> {


### PR DESCRIPTION
This pull request updates the CA import workflow to use signing profiles instead of custom expiration settings. It introduces a signing profile selector to the CA import form, updates how signing profiles are fetched and managed, and modifies the payload structure for CA import requests. Additionally, it makes minor improvements to UI text for clarity.

**CA Import Workflow Updates:**

* Replaces the expiration input in the CA import form with a `SigningProfileSelector` component, allowing users to select or create a signing profile for certificate issuance. (`src/app/certificate-authorities/new/import-full/page.tsx` [[1]](diffhunk://#diff-0fe8f603f3d981b722ed084543d68832b20a244e9ff48c6526e7341b9395d294L23-R26) [[2]](diffhunk://#diff-0fe8f603f3d981b722ed084543d68832b20a244e9ff48c6526e7341b9395d294L62-R68) [[3]](diffhunk://#diff-0fe8f603f3d981b722ed084543d68832b20a244e9ff48c6526e7341b9395d294L208-R249)
* Adds logic to load available signing profiles for the authenticated user, manage profile selection state, and handle creation of new profiles. (`src/app/certificate-authorities/new/import-full/page.tsx` [[1]](diffhunk://#diff-0fe8f603f3d981b722ed084543d68832b20a244e9ff48c6526e7341b9395d294R81-R104) [[2]](diffhunk://#diff-0fe8f603f3d981b722ed084543d68832b20a244e9ff48c6526e7341b9395d294R193-R198)

**API and Data Model Changes:**

* Updates the `ImportCaPayload` interface to remove expiration fields and add a `profile_id` field, reflecting the new requirement to associate imported CAs with a signing profile. (`src/lib/ca-data.ts` [src/lib/ca-data.tsL702-R709](diffhunk://#diff-b58e8121e5f9c2b94df524e9613dce09c12098aa56e318b3c19368ce48d4b8a8L702-R709))
* Modifies the CA import submission logic to send the selected `profile_id` instead of custom expiration data. (`src/app/certificate-authorities/new/import-full/page.tsx` [src/app/certificate-authorities/new/import-full/page.tsxL152-R174](diffhunk://#diff-0fe8f603f3d981b722ed084543d68832b20a244e9ff48c6526e7341b9395d294L152-R174))

**UI Improvements:**

* Updates the title for the "generate" CA creation mode to clarify that it creates a new key pair. (`src/app/certificate-authorities/new/page.tsx` [src/app/certificate-authorities/new/page.tsxL24-R24](diffhunk://#diff-775ebcec93539211891b1cfd383c6f3ff02a7f4bdce289529f4f21d5d5a36445L24-R24))

**Bug Fixes:**

* Fixes a bug where the full list of signing profiles was not correctly set after fetching. (`src/app/certificate-authorities/issue-certificate/IssueCertificateFormClient.tsx` [src/app/certificate-authorities/issue-certificate/IssueCertificateFormClient.tsxL242-R242](diffhunk://#diff-30bf97edf687b80b4835caece340135522f14023ed623a04b6828a7dec1785f6L242-R242))