### PR TITLE
feat: at devices force update allow to select platform integration to use when more than one is defined for the RA

### DIFF
--- a/src/components/shared/ForceUpdateModal.tsx
+++ b/src/components/shared/ForceUpdateModal.tsx
@@ -49,6 +49,8 @@ export const ForceUpdateModal: React.FC<ForceUpdateModalProps> = ({
   useEffect(() => {
     if (isOpen && availableIntegrations.length > 0) {
       setSelectedIntegrationKey(availableIntegrations[0].configKey);
+    } else {
+      setSelectedIntegrationKey('');
     }
   }, [isOpen, availableIntegrations]);
 


### PR DESCRIPTION
This pull request updates the device details and force update modal to support multiple platform integrations per device, improving flexibility and user experience. The main changes involve replacing the single active integration state with support for multiple integrations, updating the force update workflow to allow users to select the desired integration, and enhancing the modal UI accordingly.

**Device integration management:**

* Replaced the `activeIntegration` state with an `availableIntegrations` array in `DeviceDetailsClient.tsx`, updating logic to filter and store all integrations relevant to the device's registration authority. [[1]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL95-R96) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL126-R135) [[3]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL166-R170)
* Updated the force update button to display if there is at least one available integration, rather than relying on a single active integration.

**Force update workflow and modal enhancements:**

* Modified the force update handler and modal props to support multiple integrations: the handler now receives a `configKey` for the selected integration, and the modal receives the `availableIntegrations` array instead of a single integration. [[1]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL531-R544) [[2]](diffhunk://#diff-576edef306c1be8c9b6d8f496d2f32811f6a05efa635930c05a29e552ae91d8cL887-R891) [[3]](diffhunk://#diff-3cfb0cf828c91de6674411764aec507058bc2f44cd366606ab669023792fd5b7R24-R32) [[4]](diffhunk://#diff-3cfb0cf828c91de6674411764aec507058bc2f44cd366606ab669023792fd5b7L40-R64)
* Refactored `ForceUpdateModal` to allow users to select from multiple integrations using a dropdown (`Select` component), and to display integration details accordingly. The modal disables the confirm button if no integration is selected. [[1]](diffhunk://#diff-3cfb0cf828c91de6674411764aec507058bc2f44cd366606ab669023792fd5b7L62-L63) [[2]](diffhunk://#diff-3cfb0cf828c91de6674411764aec507058bc2f44cd366606ab669023792fd5b7L82-R124) [[3]](diffhunk://#diff-3cfb0cf828c91de6674411764aec507058bc2f44cd366606ab669023792fd5b7L138-R168)
* Improved modal state management: when opened, the modal auto-selects the first available integration if present.

These changes collectively enable users to select which integration to use when forcing a device update, enhancing clarity and control in environments with multiple integrations.