### PR TITLE
fix: force update actions propagation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextn",
-  "version": "4.0.2",
+  "version": "4.0.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -p 9002",

--- a/src/app/devices/details/DeviceDetailsClient.tsx
+++ b/src/app/devices/details/DeviceDetailsClient.tsx
@@ -941,7 +941,7 @@ export default function DeviceDetailsClient() {
       <ForceUpdateModal
         isOpen={isForceUpdateModalOpen}
         onOpenChange={setIsForceUpdateModalOpen}
-        onConfirm={(actions) => handleForceUpdateConfirm(activeIntegration!.configKey, actions)}
+        onConfirm={(configKey,actions) => handleForceUpdateConfirm(configKey, actions)}
         device={device}
         ra={raForIntegration}
         availableIntegrations={availableIntegrations}


### PR DESCRIPTION
This pull request contains a version bump for the project and a small update to the `DeviceDetailsClient` component to improve how force update confirmations are handled.

Version update:

* Bumped the project version in `package.json` from `4.0.2` to `4.0.5`.

Device details improvements:

* Updated the `onConfirm` prop in `DeviceDetailsClient.tsx` to receive `configKey` as a parameter instead of relying on `activeIntegration!.configKey`, making the handler more flexible and less dependent on external state.