### PR TITLE
fix: use engine key sizes 

### DIFF
--- a/src/lib/form-options.ts
+++ b/src/lib/form-options.ts
@@ -18,6 +18,7 @@ export const RSA_KEY_SIZE_OPTIONS = [
 ];
 
 export const ECDSA_CURVE_OPTIONS = [
+  { value: 'P-224', label: 'P-224 (NIST P-224, secp224r1)' },
   { value: 'P-256', label: 'P-256 (NIST P-256, secp256r1)' },
   { value: 'P-384', label: 'P-384 (NIST P-384, secp384r1)' },
   { value: 'P-521', label: 'P-521 (NIST P-521, secp521r1)' },

--- a/src/lib/key-spec-constants.ts
+++ b/src/lib/key-spec-constants.ts
@@ -11,7 +11,7 @@ export const RSA_KEY_SIZE_OPTIONS = [
 ];
 
 export const ECDSA_CURVE_OPTIONS = [
-  { value: 'P-224', label: 'P-224 (NIST P-2224, secp224r1)' },
+  { value: 'P-224', label: 'P-224 (NIST P-224, secp224r1)' },
   { value: 'P-256', label: 'P-256 (NIST P-256, secp256r1)' },
   { value: 'P-384', label: 'P-384 (NIST P-384, secp384r1)' },
   { value: 'P-521', label: 'P-521 (NIST P-521, secp521r1)' },

--- a/src/lib/key-spec-constants.ts
+++ b/src/lib/key-spec-constants.ts
@@ -1,11 +1,7 @@
+
 export const KEY_TYPE_OPTIONS = [
   { value: 'RSA', label: 'RSA' },
   { value: 'ECDSA', label: 'ECDSA' },
-];
-
-export const KEY_TYPE_OPTIONS_POST_QUANTUM = [
-  ...KEY_TYPE_OPTIONS,
-  { value: 'ML-DSA', label: 'ML-DSA (Post-Quantum)' },
 ];
 
 export const RSA_KEY_SIZE_OPTIONS = [
@@ -15,13 +11,10 @@ export const RSA_KEY_SIZE_OPTIONS = [
 ];
 
 export const ECDSA_CURVE_OPTIONS = [
+  { value: 'P-224', label: 'P-224 (NIST P-2224, secp224r1)' },
   { value: 'P-256', label: 'P-256 (NIST P-256, secp256r1)' },
   { value: 'P-384', label: 'P-384 (NIST P-384, secp384r1)' },
   { value: 'P-521', label: 'P-521 (NIST P-521, secp521r1)' },
 ];
 
-export const MLDSA_SECURITY_LEVEL_OPTIONS = [
-  { value: 'ML-DSA-44', label: 'ML-DSA-44 (Security Level 1 - ~AES-128)' },
-  { value: 'ML-DSA-65', label: 'ML-DSA-65 (Security Level 3 - ~AES-192)' },
-  { value: 'ML-DSA-87', label: 'ML-DSA-87 (Security Level 5 - ~AES-256)' },
-];
+


### PR DESCRIPTION
This pull request refactors the Certificate Authority generation form to dynamically display and validate key specification options (such as key size or curve) based on the selected crypto engine and key type. It also improves the UX by disabling form fields during submission and ensures better validation for key specification selection. Additionally, it adds support for the P-224 ECDSA curve option.

Key changes include:

### Dynamic Key Specification Handling

* The form now dynamically loads available key types and their corresponding key specification options (sizes or curves) from the selected crypto engine, rather than using static lists. This ensures only supported options are shown to the user. (`src/app/certificate-authorities/new/generate/page.tsx` [[1]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L22-R22) [[2]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743R115-R152) [[3]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L270-R327)
* The key specification (key size or curve) is now managed with a single state variable (`keySpec`) instead of separate variables for RSA and ECDSA. The label and available options update automatically based on the selected key type. (`src/app/certificate-authorities/new/generate/page.tsx` [[1]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L44-R44) [[2]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743R115-R152) [[3]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L127-L135) [[4]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L270-R327)

### Validation and Submission Improvements

* Adds validation to ensure a key specification is selected before allowing form submission, and disables all relevant form fields while the form is submitting. (`src/app/certificate-authorities/new/generate/page.tsx` [[1]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743R212-R216) [[2]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L302-R340) [[3]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L319-R357) [[4]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L344-R382) [[5]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L356-R413)
* The payload sent to the backend now consistently uses the correct number of bits for the selected key type and specification, removing the need for a separate curve-to-bits mapping function. (`src/app/certificate-authorities/new/generate/page.tsx` [[1]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743R229-R236) [[2]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L215-R251) [[3]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L149-L157)

### Key Option Constants

* Refactors key type and key spec option constants, moving them to a new file and updating imports to use the new constants. (`src/lib/key-spec-constants.ts` [[1]](diffhunk://#diff-7eee858a526c71c0366363727bf6b1a5c69f091ae6c49a5d349bfb2feeed0c89R1-R20) `src/app/certificate-authorities/new/generate/page.tsx` [[2]](diffhunk://#diff-dc7a8d6151288827b24856b7ca14f28db0f4864d5c83d076d87dc42df3344743L22-R22)
* Adds the P-224 ECDSA curve to the available options. (`src/lib/form-options.ts` [[1]](diffhunk://#diff-3540a7b1227d58aa779bf5867b8c65246e295d4cf086e3c453437c48a99b03a4R21) `src/lib/key-spec-constants.ts` [[2]](diffhunk://#diff-7eee858a526c71c0366363727bf6b1a5c69f091ae6c49a5d349bfb2feeed0c89R1-R20)

These changes make the CA generation form more robust, user-friendly, and compatible with a wider range of crypto engines and key types.