### PR TITLE
fix: ip: Indefinite validity fisualization at Issuance Profile card

### DIFF
--- a/src/components/shared/IssuanceProfileCard.tsx
+++ b/src/components/shared/IssuanceProfileCard.tsx
@@ -87,9 +87,12 @@ export const IssuanceProfileCard: React.FC<IssuanceProfileCardProps> = ({ profil
               case 'Duration':
                 return profile.validity.duration ? `Duration: ${profile.validity.duration}` : "Not specified";
               case 'Date':
+                 if (profile.validity.time?.startsWith('9999-12-31')) {
+                    return "Never Expires";
+                 }
                 return profile.validity.time ? `Until: ${new Date(profile.validity.time).toLocaleDateString()}` : "Not specified";
               case 'Indefinite':
-                return "Indefinite";
+                return "Never Expires";
               default:
                 return "Not specified";
             }


### PR DESCRIPTION
This pull request updates the display logic for validity information in the `IssuanceProfileCard` component to provide clearer messaging for profiles that never expire.

Improvements to validity messaging:

* For the "Date" validity type, if `profile.validity.time` starts with `9999-12-31`, the card now displays "Never Expires" instead of a date, making it more user-friendly.
* For the "Indefinite" validity type, the message has been changed from "Indefinite" to "Never Expires" for consistency with other expiry-related messaging.