### PR TITLE
fix: CRL modal: Auto-generate URL from CA SKI and simplify UI

### DIFF
--- a/src/components/shared/CrlCheckModal.tsx
+++ b/src/components/shared/CrlCheckModal.tsx
@@ -17,6 +17,7 @@ import { DetailItem } from './DetailItem';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/hooks/use-toast';
 import { revocationReasons } from '@/lib/revocation-reasons';
+import { CRL_BASE_PATH } from '@/lib/va-api';
 
 interface CrlCheckModalProps {
   isOpen: boolean;
@@ -60,8 +61,16 @@ export const CrlCheckModal: React.FC<CrlCheckModalProps> = ({ isOpen, onClose, c
     const [showHttpWarning, setShowHttpWarning] = useState(false);
 
     useEffect(() => {
-        if (isOpen && ca?.crlDistributionPoints && ca.crlDistributionPoints.length > 0) {
-            setCrlUrl(ca.crlDistributionPoints[0]);
+        if (isOpen && ca?.subjectKeyId) {
+            // Construct CRL URL using LAMASSU_PUBLIC_API if defined, otherwise current UI host
+            let baseUrl = '';
+            if (typeof window !== 'undefined') {
+                // Check for LAMASSU_PUBLIC_API in config first
+                const publicApi = (window as any).lamassuConfig?.LAMASSU_PUBLIC_API;
+                baseUrl = publicApi || window.location.origin;
+            }
+            const constructedCrlUrl = `${baseUrl}${CRL_BASE_PATH}/${ca.subjectKeyId}`;
+            setCrlUrl(constructedCrlUrl);
         } else {
             setCrlUrl('');
         }
@@ -141,32 +150,29 @@ export const CrlCheckModal: React.FC<CrlCheckModalProps> = ({ isOpen, onClose, c
                 <DialogHeader>
                     <DialogTitle className="flex items-center"><FileText className="mr-2 h-6 w-6 text-primary"/>CRL Viewer</DialogTitle>
                     <DialogDescription>
-                        Fetch and parse a Certificate Revocation List for CA: <span className="font-mono text-xs">{ca?.name}</span>.
+                        Fetch and parse the Certificate Revocation List issued by CA: <span className="font-mono text-xs">{ca?.name}</span>.
                     </DialogDescription>
                 </DialogHeader>
 
                 <div className="py-2 space-y-4">
                     <div className="space-y-3">
                         <div>
-                            <Label htmlFor="crl-url-select">Select a discovered URL</Label>
-                            <Select value={crlUrl} onValueChange={setCrlUrl} disabled={isLoading || !ca?.crlDistributionPoints?.length}>
-                                <SelectTrigger id="crl-url-select">
-                                    <SelectValue placeholder="Select from certificate's CDP..." />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {ca?.crlDistributionPoints?.map(url => (
-                                        <SelectItem key={url} value={url}>{url}</SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-                        <div className="relative">
-                            <div className="absolute inset-0 flex items-center"><span className="w-full border-t" /></div>
-                            <div className="relative flex justify-center text-xs uppercase"><span className="bg-background px-2 text-muted-foreground">Or</span></div>
-                        </div>
-                        <div>
-                            <Label htmlFor="crl-url-input">Enter URL manually</Label>
-                            <Input id="crl-url-input" type="text" placeholder="http://crl.example.com/ca.crl" value={crlUrl} onChange={(e) => setCrlUrl(e.target.value)} disabled={isLoading} className="mt-1"/>
+                            <Label htmlFor="crl-url-input">CRL URL</Label>
+                            <Input 
+                                id="crl-url-input" 
+                                type="text" 
+                                placeholder="Enter CRL URL" 
+                                value={crlUrl} 
+                                onChange={(e) => setCrlUrl(e.target.value)} 
+                                disabled={isLoading} 
+                                className="mt-1 font-mono text-xs"
+                            />
+                            <p className="text-xs text-muted-foreground mt-1">
+                                {ca?.subjectKeyId 
+                                    ? `Auto-generated URL using ${(typeof window !== 'undefined' && (window as any).lamassuConfig?.LAMASSU_PUBLIC_API) ? 'LAMASSU_PUBLIC_API' : 'current domain'} + CA's SKI: ${ca.subjectKeyId}` 
+                                    : 'Enter the CRL URL manually'
+                                }
+                            </p>
                         </div>
                     </div>
                     {showHttpWarning && (

--- a/src/lib/ca-data.ts
+++ b/src/lib/ca-data.ts
@@ -328,7 +328,7 @@ export async function parseCertificatePemDetails(pem: string): Promise<ParsedPem
             if (skiExtension?.parsedValue) {
                 const ski = skiExtension.parsedValue;
                 if (ski.valueBlock?.valueHex) {
-                    defaultResult.subjectKeyId = ab2hex(ski.valueBlock.valueHex, ':');
+                    defaultResult.subjectKeyId = ab2hex(ski.valueBlock.valueHex);
                 }
             }
         } catch(e) { console.error("Failed to parse Subject Key Identifier:", e); }

--- a/src/lib/va-api.ts
+++ b/src/lib/va-api.ts
@@ -2,6 +2,9 @@
 // src/lib/va-api.ts
 import { get_VA_API_BASE_URL, get_VA_CORE_API_BASE_URL, handleApiError } from './api-domains';
 
+// CRL base path for constructing CRL URLs
+export const CRL_BASE_PATH = '/va/crl';
+
 export interface VAConfig {
   caId: string;
   refreshInterval: string;


### PR DESCRIPTION
This pull request updates the CRL (Certificate Revocation List) viewer modal to improve how the CRL URL is determined and presented to users. The main change is that the modal now auto-generates the CRL URL using the CA's Subject Key Identifier (SKI) and the public API base path, simplifying the user experience and reducing manual input errors. Additionally, the UI for selecting or entering the CRL URL has been streamlined, and the SKI formatting has been standardized.

**CRL URL Generation and UI Simplification:**

* The CRL URL is now auto-generated using the CA's `subjectKeyId` and the `LAMASSU_PUBLIC_API` base path (falling back to the current domain if not set), improving reliability and consistency. (`src/components/shared/CrlCheckModal.tsx`, [src/components/shared/CrlCheckModal.tsxL63-R73](diffhunk://#diff-281553ebeca53bd20d695335c6f0c4db6a41b7a23e58d8580089cad98200c98eL63-R73))
* The modal UI for CRL URL input has been simplified: the dropdown for discovered URLs and manual entry options have been replaced with a single input field and an explanatory note about how the URL is generated. (`src/components/shared/CrlCheckModal.tsx`, [src/components/shared/CrlCheckModal.tsxL144-R175](diffhunk://#diff-281553ebeca53bd20d695335c6f0c4db6a41b7a23e58d8580089cad98200c98eL144-R175))
* Added the constant `CRL_BASE_PATH` to centralize the CRL API path used for constructing URLs. (`src/lib/va-api.ts`, [src/lib/va-api.tsR5-R7](diffhunk://#diff-1b4a036067a1f3291174438270ce8040336bc194c99df790689fde4c21d7fc03R5-R7))

**Technical Improvements:**

* SKI values are now formatted without colons, standardizing the output for URL construction and display. (`src/lib/ca-data.ts`, [src/lib/ca-data.tsL331-R331](diffhunk://#diff-b58e8121e5f9c2b94df524e9613dce09c12098aa56e318b3c19368ce48d4b8a8L331-R331))
* Minor update to the modal description for clarity. (`src/components/shared/CrlCheckModal.tsx`, [src/components/shared/CrlCheckModal.tsxL144-R175](diffhunk://#diff-281553ebeca53bd20d695335c6f0c4db6a41b7a23e58d8580089cad98200c98eL144-R175))

These changes make the CRL checking workflow more user-friendly and robust by reducing manual steps and potential errors.