### PR TITLE
fix: include accept header in the CRL and OCSP requests

### DIFF
--- a/src/components/shared/CrlCheckModal.tsx
+++ b/src/components/shared/CrlCheckModal.tsx
@@ -89,7 +89,11 @@ export const CrlCheckModal: React.FC<CrlCheckModalProps> = ({ isOpen, onClose, c
                 setEngine("webcrypto", getCrypto());
             }
 
-            const response = await fetch(crlUrl);
+            const response = await fetch(crlUrl,{
+                headers: {
+                    'Accept': 'application/pkix-crl, */*',
+                },
+            });
             if (!response.ok) {
                 throw new Error(`Failed to fetch CRL. Server responded with HTTP ${response.status}`);
             }

--- a/src/components/shared/OcspCheckModal.tsx
+++ b/src/components/shared/OcspCheckModal.tsx
@@ -220,7 +220,9 @@ export const OcspCheckModal: React.FC<OcspCheckModalProps> = ({ isOpen, onClose,
 
             const response = await fetch(ocspUrl, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/ocsp-request' },
+                headers: { 'Content-Type': 'application/ocsp-request',
+                    'Acept': 'application/ocsp-response'
+                 },
                 body: requestBody
             });
 


### PR DESCRIPTION
This pull request updates how HTTP requests are made in the CRL and OCSP check modals to improve standards compliance and ensure correct response formats. The most important changes are:

**HTTP request header improvements:**

* In `CrlCheckModal.tsx`, the `fetch` request for the CRL now includes an `Accept` header set to `application/pkix-crl, */*` to explicitly request the correct content type from the server.
* In `OcspCheckModal.tsx`, the `fetch` request for OCSP now attempts to include an `Accept` header (though there is a typo: `'Acept'` instead of `'Accept'`) with value `application/ocsp-response`, aiming to specify the expected response content type.